### PR TITLE
riscv: dts: bl808: add syscon device node

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -61,6 +61,13 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		syscon: syscon@0x20000000 {
+			compatible = "syscon", "simple-mfd";
+			reg = <0x20000000 0x1000>;
+			status = "okay";
+			reg-io-width = <4>;
+		};
+
 		pinctrl: pinctrl@0x200008C4 {
 			compatible = "bflb,bl808-pinctrl";
 			reg = <0x200008C4 0x1000>;


### PR DESCRIPTION
	Add device node 'syscon' which maps to global control registers,
	like clock, reset, pinmux, .etc