### PR TITLE
usb: bl808: add usb driver

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
@@ -1,7 +1,4 @@
 // SPDX-License-Identifier: (GPL-2.0+ or MIT)
-/*
- * Copyright (C) 2022 Jisheng Zhang <jszhang@kernel.org>
- */
 
 /dts-v1/;
 
@@ -104,4 +101,8 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&spidev_pins>;
 	};
+};
+
+&usb {
+	status = "okay";
 };

--- a/arch/riscv/boot/dts/bouffalolab/bl808-sipeed-m1s.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-sipeed-m1s.dts
@@ -1,7 +1,4 @@
 // SPDX-License-Identifier: (GPL-2.0+ or MIT)
-/*
- * Copyright (C) 2022 Jisheng Zhang <jszhang@kernel.org>
- */
 
 /dts-v1/;
 
@@ -127,4 +124,8 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&spidev_pins>;
 	};
+};
+
+&usb {
+	status = "okay";
 };

--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -75,6 +75,13 @@
 			reg-io-width = <4>;
 		};
 
+		pds_ctrl: pds-ctrl@0x2000e000 {
+			compatible = "syscon";
+			reg = <0x2000e000 0x1000>;
+			status = "okay";
+			reg-io-width = <4>;
+		};
+
 		pinctrl: pinctrl@0x200008C4 {
 			compatible = "bflb,bl808-pinctrl";
 			reg = <0x200008C4 0x1000>;
@@ -220,6 +227,14 @@
 			status = "disabled";
 		};
 
+		usb: usb@20072000 {
+			compatible = "faraday,fotg210", "bflb,bl808-usb";
+			reg = <0x20072000 0x1000>;
+			interrupts-extended = <&m0ic 21>;
+			syscon = <&sys_ctrl>;
+			pds = <&pds_ctrl>;
+			status = "disabled";
+		};
 		/*
 		ipclic: mailbox@30005000 {
 			compatible = "bflb,bl808-ipc";

--- a/drivers/usb/fotg210/Kconfig
+++ b/drivers/usb/fotg210/Kconfig
@@ -4,8 +4,6 @@ config USB_FOTG210
 	tristate "Faraday FOTG210 USB2 Dual Role controller"
 	depends on USB || USB_GADGET
 	depends on HAS_DMA && HAS_IOMEM
-	depends on ARCH_GEMINI || COMPILE_TEST
-	default ARCH_GEMINI
 	select MFD_SYSCON
 	help
 	  Faraday FOTG210 is a dual-mode USB controller that can act
@@ -34,5 +32,14 @@ config USB_FOTG210_UDC
 
 	   Say "y" to link the driver statically, or "m" to build a
 	   dynamically linked module called "fotg210-udc".
+
+config BFLB_FOTG210_PATCH
+	bool "Bouffalo Lab patch for setting up FOTG210"
+	depends on USB=y || USB=USB_FOTG210
+	default n
+	help
+		USB platform initialization like enable clock,
+		configure PLL and PDS, etc.
+		Say Y here to enable FOTG210 in Bouffalo Lab SoC.
 
 endif

--- a/drivers/usb/fotg210/fotg210-hcd.c
+++ b/drivers/usb/fotg210/fotg210-hcd.c
@@ -5539,8 +5539,12 @@ static void fotg210_init(struct fotg210_hcd *fotg210)
 {
 	u32 value;
 
+#ifdef CONFIG_BFLB_FOTG210_PATCH
 	iowrite32(GMIR_MDEV_INT | GMIR_MOTG_INT | GMIR_INT_POLARITY,
 			&fotg210->regs->gmir);
+#else
+	iowrite32(GMIR_MDEV_INT | GMIR_MOTG_INT, &fotg210->regs->gmir);
+#endif
 
 	value = ioread32(&fotg210->regs->otgcsr);
 	value &= ~OTGCSR_A_BUS_DROP;


### PR DESCRIPTION
	1. FOTG-210 can be integrated into any SoCs, thus remove the dependency of Cortina Gemini SoC.
	2. Do platform initialization when probe a device and set polarity of interrupt trigger.

	But this patch is ugly:
	1. Enabling clock can be done with a fine clock driver, rather than writing registers directly.
	2. Enabling power setting can be done using a power domain driver.